### PR TITLE
jump_targets as tuple again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+test:
+	python test_byteflow2.py
+	python test_simulate.py
+	python testfig3.py
+	python testfig4.py
+	python testing.py

--- a/byteflow2.py
+++ b/byteflow2.py
@@ -383,8 +383,8 @@ class BlockMap:
                                begin=synth_assign,
                                end=ControlLabel("end"),
                                fallthrough=True,
-                               jump_targets=set((new_label,)),
-                               backedges=set(),
+                               jump_targets=(new_label,),
+                               backedges=(),
                                variable_assignment=variable_assignment,
                 )
                 # add block
@@ -1340,7 +1340,7 @@ def restructure_branch(bbmap: BlockMap):
             # Insert SyntheticBranch
             tail_headers, _ = bbmap.find_headers_and_entries(tail_region_blocks)
             synthetic_branch_block_label = SyntheticBranch(bbmap.clg.new_index())
-            bbmap.insert_block(synthetic_branch_block_label, {begin}, tail_headers)
+            bbmap.insert_block(synthetic_branch_block_label, (begin,), tail_headers)
 
     # Recompute regions.
     head_region_blocks = find_head_blocks(bbmap, begin)

--- a/byteflow2.py
+++ b/byteflow2.py
@@ -349,7 +349,11 @@ class BlockMap:
             jt = list(block.jump_targets)
             if successors:
                 for s in successors:
-                    jt[jt.index(s)] = new_label
+                    if s in jt:
+                        if new_label not in jt:
+                            jt[jt.index(s)] = new_label
+                        else:
+                            jt.pop(jt.index(s))
             else:
                 jt.append(new_label)
             self.add_block(block.replace_jump_targets(jump_targets=tuple(jt)))

--- a/byteflow2.py
+++ b/byteflow2.py
@@ -856,7 +856,8 @@ def loop_rotate(bbmap: BlockMap, loop: Set[Label]):
                     # no need to add a backedge, since it will be contained in
                     # the SyntheticExitingLatch later on.
                     for h in headers:
-                        jts.remove(h)
+                        if h in jts:
+                            jts.remove(h)
                     bbmap.add_block(block.replace_jump_targets(
                                     jump_targets=tuple(jts)))
                     synth_assign_block = ControlVariableBlock(

--- a/example.py
+++ b/example.py
@@ -181,14 +181,24 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 
-def foo():
-    for i in range(10):
-        with call_context:
-            print(i)
-            if i == 5:
-                print("A")
+#def foo():
+#    for i in range(10):
+#        with call_context:
+#            print(i)
+#            if i == 5:
+#                print("A")
+#                break
+#    return i
+
+def foo(x):
+    c = 0
+    for i in range(x):
+        c += i
+        for j in range(x):
+            c += j
+            if c > 100:
                 break
-    return i
+    return c
 
 flow = ByteFlow.from_bytecode(foo)
 ByteFlowRenderer().render_byteflow(flow).view("before")

--- a/simulator.py
+++ b/simulator.py
@@ -1,4 +1,4 @@
-from collections import defaultdict, ChainMap
+from collections import ChainMap
 from dis import Instruction
 from byteflow2 import (ByteFlow, BlockMap, BCLabel, BasicBlock, RegionBlock,
                        ControlLabel, SyntheticForIter, SynthenticAssignment,
@@ -6,6 +6,7 @@ from byteflow2 import (ByteFlow, BlockMap, BCLabel, BasicBlock, RegionBlock,
                        SyntheticReturn, SyntheticTail,
                        )
 import builtins
+
 
 class Simulator:
     """BlockMap simulator"""
@@ -55,7 +56,6 @@ class Simulator:
             [br_false] = bb.backedges
             return {"jumpto": br_true if self.branch else br_false}
         elif bb.jump_targets:
-            #[br_true, br_false] = bb.jump_targets
             [br_false, br_true] = bb.jump_targets
             return {"jumpto": br_true if self.branch else br_false}
         else:
@@ -89,9 +89,10 @@ class Simulator:
         self.ctrl_varmap.update(block.variable_assignment)
 
     def _synth_branch(self, control_label, block):
-        jump_target = block.branch_value_table[self.ctrl_varmap[block.variable]]
+        jump_target = block.branch_value_table[
+            self.ctrl_varmap[block.variable]]
         if block.backedges:
-            self.branch = not jump_target in block.backedges
+            self.branch = jump_target not in block.backedges
         else:
             self.branch = bool(block.jump_targets.index(jump_target))
 
@@ -166,7 +167,6 @@ class Simulator:
     def op_INPLACE_ADD(self, inst):
         rhs = self.stack.pop()
         lhs = self.stack.pop()
-        #breakpoint()
         lhs += rhs
         self.stack.append(lhs)
 

--- a/test_simulate.py
+++ b/test_simulate.py
@@ -37,7 +37,7 @@ def test_simple_for_loop():
 
     # loop case
     sim = Simulator(flow, foo.__globals__)
-    assert sim.run(dict(x=1)) == foo(x=1)
+    assert sim.run(dict(x=2)) == foo(x=2)
 
     # extended loop case
     sim = Simulator(flow, foo.__globals__)
@@ -57,8 +57,6 @@ def test_for_loop_with_exit():
     flow = ByteFlow.from_bytecode(foo)
     flow = flow.restructure()
 
-    ByteFlowRenderer().render_byteflow(flow).view()
-
     # loop bypass case
     sim = Simulator(flow, foo.__globals__)
     ret = sim.run(dict(x=0))
@@ -75,47 +73,44 @@ def test_for_loop_with_exit():
     assert ret == foo(x=15)
 
 
-#def bar(x):
-#    c = 0
-#    for i in range(x):
-#        c += i
-#        if c <= 0:
-#            continue
-#        else:
-#            for j in range(c):
-#                c += j
-#                if c > 100:
-#                    break
-#    return c
-
-def bar(x):
-    c = 0
-    for i in range(x):
-        c += i
-        for j in range(x):
-            c += j
-            if c > 100:
-                break
-    return c
-
-
 def test_bar():
+    #def bar(x):
+    #    c = 0
+    #    for i in range(x):
+    #        c += i
+    #        if c <= 0:
+    #            continue
+    #        else:
+    #            for j in range(c):
+    #                c += j
+    #                if c > 100:
+    #                    break
+    #    return c
+
+    def bar(x):
+        c = 0
+        for i in range(x):
+            c += i
+            for j in range(x):
+                c += j
+                if c > 20:
+                    break
+
+        return c
+
     flow = ByteFlow.from_bytecode(bar)
     flow = flow.restructure()
 
-    ByteFlowRenderer().render_byteflow(flow).view()
+    sim = Simulator(flow, bar.__globals__)
+    ret = sim.run(dict(x=0))
+    assert ret == bar(x=0)
 
     sim = Simulator(flow, bar.__globals__)
-    ret = sim.run(dict(x=10))
-    #breakpoint()
-    assert ret == bar(x=10)
-
-    # sim = Simulator(rtsflow, foo.__globals__)
-    # ret = sim.run(dict(x=3))
-    # assert ret == foo(x=3)
+    ret = sim.run(dict(x=5))
+    assert ret == bar(x=5)
 
 
 if __name__ == "__main__":
-    #test_simple_for_loop()
-    #test_for_loop_with_exit()
+    test_simple_for_loop()
+    test_for_loop_with_exit()
     test_bar()

--- a/test_simulate.py
+++ b/test_simulate.py
@@ -74,32 +74,34 @@ def test_for_loop_with_exit():
 
 
 def test_bar():
-    #def bar(x):
-    #    c = 0
-    #    for i in range(x):
-    #        c += i
-    #        if c <= 0:
-    #            continue
-    #        else:
-    #            for j in range(c):
-    #                c += j
-    #                if c > 100:
-    #                    break
-    #    return c
-
     def bar(x):
         c = 0
         for i in range(x):
             c += i
-            for j in range(x):
-                c += j
-                if c > 20:
-                    break
-
+            if c <= 0:
+                continue
+            else:
+                for j in range(c):
+                    c += j
+                    if c > 100:
+                        break
         return c
+
+    #def bar(x):
+    #    c = 0
+    #    for i in range(x):
+    #        c += i
+    #        for j in range(x):
+    #            c += j
+    #            if c > 20:
+    #                break
+
+    #    return c
 
     flow = ByteFlow.from_bytecode(bar)
     flow = flow.restructure()
+
+    ByteFlowRenderer().render_byteflow(flow).view()
 
     sim = Simulator(flow, bar.__globals__)
     ret = sim.run(dict(x=0))

--- a/testing.py
+++ b/testing.py
@@ -5,7 +5,7 @@ from unittest import TestCase, main
 
 from byteflow2 import (Label, ControlLabel, BasicBlock, BlockMap,
                        ByteFlowRenderer, ByteFlow, ControlLabelGenerator,
-                       loop_rotate, SynthenticTail, SynthenticExit)
+                       loop_rotate, SyntheticTail, SyntheticExit)
 
 
 def from_yaml(yaml_string):
@@ -21,8 +21,8 @@ def from_yaml(yaml_string):
             begin_label,
             end_label,
             fallthrough=len(jump_targets) == 1,
-            backedges=set(),
-            jump_targets=set((ControlLabel(i) for i in jump_targets))
+            backedges=(),
+            jump_targets=tuple((ControlLabel(i) for i in jump_targets))
         )
         block_map_graph[begin_label] = block
     return BlockMap(block_map_graph, clg=clg)
@@ -278,7 +278,7 @@ class TestJoinTailsAndExits(MapComparator):
 
         self.assertMapEqual(expected_block_map, original_block_map)
         self.assertEqual(ControlLabel("0"), solo_tail_label)
-        self.assertEqual(SynthenticExit("4"), solo_exit_label)
+        self.assertEqual(SyntheticExit("4"), solo_exit_label)
 
     def test_join_tails_and_exits_case_02_01(self):
         original = """
@@ -311,7 +311,7 @@ class TestJoinTailsAndExits(MapComparator):
         solo_tail_label, solo_exit_label = original_block_map.join_tails_and_exits(tails, exits)
 
         self.assertMapEqual(expected_block_map, original_block_map)
-        self.assertEqual(SynthenticTail("4"), solo_tail_label)
+        self.assertEqual(SyntheticTail("4"), solo_tail_label)
         self.assertEqual(ControlLabel("3"), solo_exit_label)
 
     def test_join_tails_and_exits_case_02_02(self):
@@ -347,7 +347,7 @@ class TestJoinTailsAndExits(MapComparator):
                                                     original_block_map)).view("before")
         solo_tail_label, solo_exit_label = original_block_map.join_tails_and_exits(tails, exits)
         self.assertMapEqual(expected_block_map, original_block_map)
-        self.assertEqual(SynthenticTail("4"), solo_tail_label)
+        self.assertEqual(SyntheticTail("4"), solo_tail_label)
         self.assertEqual(ControlLabel("3"), solo_exit_label)
 
     def test_join_tails_and_exits_case_03_01(self):
@@ -391,8 +391,8 @@ class TestJoinTailsAndExits(MapComparator):
         exits = self.wrap_id(("3", "4"))
         solo_tail_label, solo_exit_label = original_block_map.join_tails_and_exits(tails, exits)
         self.assertMapEqual(expected_block_map, original_block_map)
-        self.assertEqual(SynthenticTail("6"), solo_tail_label)
-        self.assertEqual(SynthenticExit("7"), solo_exit_label)
+        self.assertEqual(SyntheticTail("6"), solo_tail_label)
+        self.assertEqual(SyntheticExit("7"), solo_exit_label)
 
     def test_join_tails_and_exits_case_03_02(self):
 
@@ -434,8 +434,8 @@ class TestJoinTailsAndExits(MapComparator):
         exits = self.wrap_id(("3", "4"))
         solo_tail_label, solo_exit_label = original_block_map.join_tails_and_exits(tails, exits)
         self.assertMapEqual(expected_block_map, original_block_map)
-        self.assertEqual(SynthenticTail("6"), solo_tail_label)
-        self.assertEqual(SynthenticExit("7"), solo_exit_label)
+        self.assertEqual(SyntheticTail("6"), solo_tail_label)
+        self.assertEqual(SyntheticExit("7"), solo_exit_label)
 
 
 class TestLoopRotate(MapComparator):


### PR DESCRIPTION
reinstate storing the jump_targets as tuples again. This also fixes a bunch of stuff and adds enough ops to the simulator to be able to simulate some more advanced programs.